### PR TITLE
Removed space in datasource url which causes plugin to fail

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -37,7 +37,7 @@ export class DarkSkyDatasource {
     }
     return this.doRequest({
       query,
-      url: `${this.apiUrl}/${this.lat}, ${this.lon}`,
+      url: `${this.apiUrl}/${this.lat},${this.lon}`,
       method: 'GET',
     }).then((res: any) => {
       // get all properties from forecast query


### PR DESCRIPTION
Currently the space present in the URL interpolation is being encoded as "%20" which then forms an invalid request.

Removing it lets the plugin save the datasource.

![image](https://user-images.githubusercontent.com/7876802/150981739-1a4e3edc-26fc-4b99-b1d5-b49aa3fa4b31.png)
